### PR TITLE
refactor function to get pr number

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,12 +7,6 @@ inputs:
     description: 'a github access token'
     required: true
     default: ${{ github.token }}
-  pr_url:
-    description:
-      'the target pr url. This is used for taking pr number in workflows
-      triggered by "issue_comment" event'
-    required: true
-    default: ${{ github.event.issue.pull_request.url }}
   threshold:
     description:
       'a threshold at which a message is sent when the number of comments

--- a/dist/index.js
+++ b/dist/index.js
@@ -29205,18 +29205,16 @@ exports.getOption = void 0;
 const core_1 = __nccwpck_require__(9093);
 const github_1 = __nccwpck_require__(5942);
 function getPrNumber() {
-    if (typeof github_1.context.payload.pull_request?.number === 'number') {
-        return github_1.context.payload.pull_request.number;
-    }
-    const url = (0, core_1.getInput)('pr_url', { required: false });
-    const numberFromUrl = Number(url.substring(url.lastIndexOf('/') + 1));
-    return numberFromUrl;
+    return (github_1.context.payload.issue?.number ||
+        github_1.context.payload.pull_request?.number ||
+        // expect to either issue.number or pull_request.number be non-undefined, so it wouldn't be NaN
+        NaN);
 }
 function getOption() {
     const token = (0, core_1.getInput)('github_token', { required: true });
     const prNumber = getPrNumber();
-    if (isNaN(prNumber) || prNumber === 0) {
-        (0, core_1.setFailed)('pr number is not set properly');
+    if (isNaN(prNumber)) {
+        (0, core_1.setFailed)('fail to get pr number');
     }
     const threshold = Number((0, core_1.getInput)('threshold', { required: true }));
     return {

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -1,0 +1,54 @@
+import { getOption } from './option';
+import { context } from '@actions/github';
+
+const mockedContext = jest.mocked(context);
+
+jest.mock('@actions/core', () => ({
+  getInput: (name: string) => {
+    if (name === 'threshold') return '100';
+    return `value-${name}`;
+  },
+  setFailed: () => {
+    throw new Error();
+  },
+}));
+
+describe('if the event is triggered by "pull_request_review_comment"', () => {
+  beforeEach(() => {
+    mockedContext.payload = {
+      pull_request: {
+        number: 5,
+      },
+      issue: undefined,
+    };
+  });
+
+  test('return pr number from "context.payload.pull_request.number"', () => {
+    const option = getOption();
+    expect(option).toStrictEqual({
+      prNumber: 5,
+      threshold: 100,
+      token: 'value-github_token',
+    });
+  });
+});
+
+describe('if the event is triggered by "issue_comment"', () => {
+  beforeEach(() => {
+    mockedContext.payload = {
+      pull_request: undefined,
+      issue: {
+        number: 5,
+      },
+    };
+  });
+
+  test('return pr number from "context.payload.issue.number"', () => {
+    const option = getOption();
+    expect(option).toStrictEqual({
+      prNumber: 5,
+      threshold: 100,
+      token: 'value-github_token',
+    });
+  });
+});

--- a/src/option.ts
+++ b/src/option.ts
@@ -7,22 +7,21 @@ type Option = {
   threshold: number;
 };
 
-function getPrNumber(): number {
-  if (typeof context.payload.pull_request?.number === 'number') {
-    return context.payload.pull_request.number;
-  }
-
-  const url = getInput('pr_url', { required: false });
-  const numberFromUrl = Number(url.substring(url.lastIndexOf('/') + 1));
-  return numberFromUrl;
+function getPrNumber() {
+  return (
+    context.payload.issue?.number ||
+    context.payload.pull_request?.number ||
+    // expect to either issue.number or pull_request.number be non-undefined, so it wouldn't be NaN
+    NaN
+  );
 }
 
 export function getOption(): Option {
   const token = getInput('github_token', { required: true });
 
   const prNumber = getPrNumber();
-  if (isNaN(prNumber) || prNumber === 0) {
-    setFailed('pr number is not set properly');
+  if (isNaN(prNumber)) {
+    setFailed('fail to get pr number');
   }
 
   const threshold = Number(getInput('threshold', { required: true }));


### PR DESCRIPTION
update getting pr number logic.

- issue_comment event ... `context.payload.issue.number`
- pull_request_review_comment event ... `context.payload.pull_request.number`

I checked it works on https://github.com/tnyo43/github-action-take-issue-number-on-issue-comment/pull/3